### PR TITLE
Use ApiClient basePath in API calls

### DIFF
--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/Client/ApiClient.cs
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/Client/ApiClient.cs
@@ -193,7 +193,14 @@ namespace CyberSource.Client
                         ParameterType.HttpHeader);
                 }
                 else
+                {
+                    if (request.Parameters.Any(x => x.Name == param.Key && x.Type == ParameterType.HttpHeader))
+                    {
+                        continue;
+                    }
+
                     request.AddHeader(param.Key, param.Value);
+                }
             }
 
             // add query parameter, if any
@@ -957,12 +964,6 @@ namespace CyberSource.Client
 
             //Set the Configuration
             Configuration.DefaultHeader = authenticationHeaders;
-            RestClient = new RestClient("https://" + merchantConfig.HostName);
-            
-            if (Configuration.Proxy != null)
-            {
-                RestClient.Proxy = Configuration.Proxy;
-            }
         }
     }
 }


### PR DESCRIPTION
Each time `CallAuthenticationHeaders` method is called a new instance of `RestClient`is created and initialized with `merchantConfig.HostName`. That makes it impossilbe to set `RestClient` baseAddress with values different than _apitest.cybersource.com_ or _cybersoure.com_.  Also there should be a possibility to override some of authentication headers like _Host_ to specify custom hostname and and port number of the server to which the request is being sent. That would allow to call Cybersource API via cloud based API management platforms e.g. Azure Api Managment