### PR TITLE
Add Timeout and UserAgent config values to CallApiAsync

### DIFF
--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/Client/ApiClient.cs
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/Client/ApiClient.cs
@@ -556,14 +556,19 @@ namespace CyberSource.Client
                 }
             }
 
-                if (logUtility.IsMaskingEnabled(logger))
-                {
-                    logger.Debug($"HTTP Request Headers :\n{logUtility.MaskSensitiveData(headerPrintOutput.ToString())}");
-                }
-                else
-                {
-                    logger.Debug($"HTTP Request Headers :\n{headerPrintOutput.ToString()}");
-                }
+            if (logUtility.IsMaskingEnabled(logger))
+            {
+                logger.Debug($"HTTP Request Headers :\n{logUtility.MaskSensitiveData(headerPrintOutput.ToString())}");
+            }
+            else
+            {
+                logger.Debug($"HTTP Request Headers :\n{headerPrintOutput.ToString()}");
+            }
+
+            // set timeout
+            RestClient.Timeout = Configuration.Timeout;
+            // set user agent
+            RestClient.UserAgent = Configuration.UserAgent;
 
             InterceptRequest(request);
             var response = await RestClient.ExecuteTaskAsync(request);


### PR DESCRIPTION
Address the behavior mentioned here https://github.com/CyberSource/cybersource-rest-client-dotnetstandard/issues/53

The timeout value not being respected is causing high CPU usage on our application, and as such is a critical fix for us.