### PR TITLE
Fix CVE-2024-45302 CRLF Injection in RestSharp

### DIFF
--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard.Test/cybersource-rest-client-netstandard.Test.csproj
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard.Test/cybersource-rest-client-netstandard.Test.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard.csproj
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NLog" Version="5.0.0" />
-    <PackageReference Include="RestSharp" Version="[108.0.3]" />
+    <PackageReference Include="RestSharp" Version="[112.0.0]" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 

--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/TestProject.mustache
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/TestProject.mustache
@@ -62,7 +62,7 @@
       <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\{{targetFrameworkNuget}}\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="RestSharp">
-        <HintPath>..\packages\RestSharp.106.5.4\lib\{{targetFrameworkNuget}}2\RestSharp.dll</HintPath>
+        <HintPath>..\packages\RestSharp.112.0.0\lib\{{targetFrameworkNuget}}2\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
         <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/compile-mono.sh.mustache
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/compile-mono.sh.mustache
@@ -16,7 +16,7 @@ mono nuget.exe install src/{{packageName}}/packages.config -o packages;
 echo "[INFO] Copy DLLs to the 'bin' folder"
 mkdir -p bin;
 cp packages/Newtonsoft.Json.10.0.3/lib/{{targetFrameworkNuget}}/Newtonsoft.Json.dll bin/Newtonsoft.Json.dll;
-cp packages/RestSharp.105.1.0/lib/{{targetFrameworkNuget}}/RestSharp.dll bin/RestSharp.dll;
+cp packages/RestSharp.112.0.0/lib/{{targetFrameworkNuget}}/RestSharp.dll bin/RestSharp.dll;
 {{#generatePropertyChanged}}
 cp packages/Fody.1.29.4/Fody.dll bin/Fody.dll
 cp packages/PropertyChanged.Fody.1.51.3/PropertyChanged.Fody.dll bin/PropertyChanged.Fody.dll

--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/compile.mustache
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/compile.mustache
@@ -16,7 +16,7 @@ if not exist ".\nuget.exe" powershell -Command "(new-object System.Net.WebClient
 if not exist ".\bin" mkdir bin
 
 copy packages\Newtonsoft.Json.10.0.3\lib\{{targetFrameworkNuget}}\Newtonsoft.Json.dll bin\Newtonsoft.Json.dll
-copy packages\RestSharp.105.1.0\lib\{{targetFrameworkNuget}}\RestSharp.dll bin\RestSharp.dll
+copy packages\RestSharp.112.0.0\lib\{{targetFrameworkNuget}}\RestSharp.dll bin\RestSharp.dll
 {{#generatePropertyChanged}}
 copy packages\Fody.1.29.4\Fody.dll bin\Fody.dll
 copy packages\PropertyChanged.Fody.1.51.3\PropertyChanged.Fody.dll bin\PropertyChanged.Fody.dll

--- a/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/netcore_testproject.mustache
+++ b/cybersource-rest-client-netstandard/cybersource-rest-client-netstandard/generator/cybersource-csharp-template/netcore_testproject.mustache
@@ -22,7 +22,7 @@
     <PackageReference Include="FubarCoder.RestSharp.Portable.Core" Version="4.0.7" />
     {{/netStandard}}
     {{^netStandard}}
-    <PackageReference Include="RestSharp" Version="105.1.0" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     {{/netStandard}}
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>


### PR DESCRIPTION
[CVE-2024-45302](https://github.com/advisories/GHSA-4rr6-2v9v-wcpc) CRLF Injection in RestSharp's `RestRequest.AddHeader` method. Update RestSharp package references to 112.0.0.